### PR TITLE
agent::xinetd: Allow to set xinetd for

### DIFF
--- a/manifests/agent/xinetd.pp
+++ b/manifests/agent/xinetd.pp
@@ -24,6 +24,10 @@
 #   (optional) Protocol for xinetd checkmk service
 #   default: 'tcp'
 #
+# [*flags*]
+#   (optional) Flags for xinetd checkmk service
+#   default: undef
+#
 # [*auto_add*]
 #   (optional) Register a exported exec resources to automatically
 #   refresh server configuration when a client is added. This functionality
@@ -36,6 +40,7 @@ class checkmk::agent::xinetd(
   $port      = '6556',
   $user      = 'root',
   $protocol  = 'tcp',
+  $flags     = undef,
   $auto_add  = false,
 ) {
 
@@ -46,6 +51,7 @@ class checkmk::agent::xinetd(
   validate_re($port, '^\d+$', 'port is not a valid port')
   validate_string($user)
   validate_string($protocol)
+  validate_string($flags)
 
   $check_only_from = join($only_from, ' ')
 
@@ -77,5 +83,4 @@ class checkmk::agent::xinetd(
   if $auto_add {
     include 'checkmk::client'
   }
-
 }

--- a/templates/check_mk_agent_xinetd.erb
+++ b/templates/check_mk_agent_xinetd.erb
@@ -45,5 +45,8 @@ service check_mk
 	# the default options will be used for this service.
 	log_on_success =
 
-	disable        = no
+    disable        = no
+<% if !@flags.nil? and !@flags.empty? -%>
+    flags          = <%= @flags %>
+<% end -%>
 }


### PR DESCRIPTION
Salut,

It's to support checkmk xinetd over ipv6 only network ;)

A+
